### PR TITLE
Added related jobs section

### DIFF
--- a/digits/dataset/images/classification/views.py
+++ b/digits/dataset/images/classification/views.py
@@ -257,9 +257,9 @@ def image_classification_dataset_create():
             scheduler.delete_job(job)
         raise
 
-def show(job):
+def show(job, related_jobs=None):
     """
     Called from digits.dataset.views.datasets_show()
     """
-    return flask.render_template('datasets/images/classification/show.html', job=job)
+    return flask.render_template('datasets/images/classification/show.html', job=job, related_jobs=related_jobs)
 

--- a/digits/dataset/views.py
+++ b/digits/dataset/views.py
@@ -24,11 +24,13 @@ def datasets_show(job_id):
     if job is None:
         raise werkzeug.exceptions.NotFound('Job not found')
 
+    related_jobs = scheduler.get_related_jobs(job)
+
     if request_wants_json():
         return flask.jsonify(job.json_dict(True))
     else:
         if isinstance(job, dataset_images.ImageClassificationDatasetJob):
-            return dataset_images.classification.views.show(job)
+            return dataset_images.classification.views.show(job, related_jobs=related_jobs)
         else:
             raise werkzeug.exceptions.BadRequest('Invalid job type')
 

--- a/digits/evaluation/images/classification/views.py
+++ b/digits/evaluation/images/classification/views.py
@@ -35,7 +35,7 @@ def image_classification_evaluation_create():
 
         job = ImageClassificationEvaluationJob(
             name=modelJob._name + "-accuracy-evaluation-epoch-" + str(epoch),
-            modeljob_id= modelJob.id(),
+            model_id= modelJob.id(),
             model_epoch= epoch
             )
 
@@ -73,9 +73,9 @@ def image_classification_evaluation_create():
         raise
 
 
-def show(job):
+def show(job, related_jobs=None):
     """
     Called from digits.evaluation.views.evaluations_show()
     """
-    return flask.render_template('evaluations/images/classification/show.html', job=job)
+    return flask.render_template('evaluations/images/classification/show.html', job=job, related_jobs=related_jobs)
 

--- a/digits/evaluation/images/job.py
+++ b/digits/evaluation/images/job.py
@@ -17,11 +17,3 @@ class ImageEvaluationJob(EvaluationJob):
 
         super(ImageEvaluationJob, self).__init__(**kwargs)
         self.pickver_job_evaluation_image = PICKLE_VERSION
-
-
-    def dependent_jobs(self):
-        """
-        Returns the list of the jobs on which the EvaluationJob
-        depends
-        """
-        raise NotImplementedError('Implement me!')

--- a/digits/job.py
+++ b/digits/job.py
@@ -182,3 +182,12 @@ class Job(StatusCls):
         except Exception as e:
             print 'Caught %s while saving job: %s' % (type(e).__name__, e)
 
+
+    def parent_jobs(self):
+        """
+        Returns the list of the jobs on which the job
+        depends
+        """
+        raise NotImplementedError('Implement me!')
+
+        

--- a/digits/model/images/classification/job.py
+++ b/digits/model/images/classification/job.py
@@ -49,3 +49,9 @@ class ImageClassificationModelJob(ImageModelJob):
                     os.path.basename(snapshot_filename)),
                 ]
 
+    @override
+    def parent_jobs(self):
+        return [self.train_task().dataset]
+
+
+

--- a/digits/model/images/classification/views.py
+++ b/digits/model/images/classification/views.py
@@ -208,11 +208,11 @@ def image_classification_model_create():
             scheduler.delete_job(job)
         raise
 
-def show(job):
+def show(job, related_jobs=None):
     """
     Called from digits.model.views.models_show()
     """
-    return flask.render_template('models/images/classification/show.html', job=job)
+    return flask.render_template('models/images/classification/show.html', job=job, related_jobs=related_jobs)
 
 @app.route(NAMESPACE + '/large_graph', methods=['GET'])
 @autodoc('models')

--- a/digits/model/views.py
+++ b/digits/model/views.py
@@ -35,12 +35,13 @@ def models_show(job_id):
     job = scheduler.get_job(job_id)
     if job is None:
         raise werkzeug.exceptions.NotFound('Job not found')
+    related_jobs = scheduler.get_related_jobs(job)
 
     if request_wants_json():
         return flask.jsonify(job.json_dict(True))
     else:
         if isinstance(job, model_images.ImageClassificationModelJob):
-            return model_images.classification.views.show(job)
+            return model_images.classification.views.show(job, related_jobs=related_jobs)
         else:
             raise werkzeug.exceptions.BadRequest(
                     'Invalid job type')

--- a/digits/templates/job.html
+++ b/digits/templates/job.html
@@ -223,6 +223,63 @@ $('#delete-job').on('click', function(event) {
         </div>
         </div>
         <div class="gpu-utilization-info" style="display:none;"></div>
+
+        <!-- Related jobs -->
+        {% if related_jobs is not none and related_jobs|length > 0 %}
+        <div class="panel-group">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h4 class="panel-title">
+                    Related jobs
+                </h4>
+            </div>
+            <div class="panel-collapse">
+                <div class="panel-body">
+                    <div class="panel-group">
+                        <!-- Related model jobs -->
+                        {% for r_job in related_jobs %}
+                        {% if r_job.job_type() == "Image Classification Model" %}
+                        {% if r_jobs_model != 1 %}
+                            <h4 class="panel-title">Image Classification Models</h4><br/>
+                            {% set r_jobs_model = 1 %}
+                        {% endif %}
+                        <div id="{{r_job.id()}}-status" class="panel panel-{{ r_job.status.css }}">
+                            <div class="panel-heading">
+                                <h4 class="panel-title">
+                                    <a target="_blank" href="/jobs/{{ r_job.id() }}">
+                                        {{ r_job.name() }}
+                                        <small>{{r_job.status.name}}</small>
+                                    </a>
+                                </h4>
+                            </div> 
+                        </div>
+                        {% endif %}
+                        {% endfor %}
+
+                        <!-- Related evaluation jobs -->
+                        {% for r_job in related_jobs %}
+                        {% if r_job.job_type() == "Image Classification Model Evaluation" %}
+                        {% if r_jobs_model_eval != 1 %}
+                            <h4 class="panel-title">Image Classification Model Evaluations</h4><br/>
+                            {% set r_jobs_model_eval = 1 %}
+                        {% endif %}
+                        <div id="{{r_job.id()}}-status" class="panel panel-{{ r_job.status.css }}">
+                            <div class="panel-heading">
+                                <h4 class="panel-title">
+                                    <a target="_blank" href="/jobs/{{ r_job.id() }}">
+                                        {{ r_job.name() }}
+                                        <small>{{r_job.status.name}}</small>
+                                    </a>
+                                </h4>
+                            </div> 
+                        </div>
+                        {% endif %}
+                        {% endfor %}
+                    </div>
+                </div>
+            </div>
+        </div>
+        {% endif %}
     </div>
 
 </div>


### PR DESCRIPTION
I added a "Related jobs" section on job show views. For example, in Dataset views, one can see all the models trained on this dataset. In Model views, one can see all the EvaluationJobs related to it. 

![Related jobs](https://cloud.githubusercontent.com/assets/5939621/8162926/8267ed8a-1380-11e5-8cc6-1ad9c2438db0.png)
